### PR TITLE
Make pool info public to be able to simplify sending metrics out for observability.

### DIFF
--- a/src/pool/mod.rs
+++ b/src/pool/mod.rs
@@ -106,7 +106,7 @@ pub struct Pool {
 }
 
 #[derive(Debug)]
-struct PoolInfo {
+pub struct PoolInfo {
     new_len: usize,
     idle_len: usize,
     tasks_len: usize,
@@ -175,7 +175,7 @@ impl Pool {
         }
     }
 
-    fn info(&self) -> PoolInfo {
+    pub fn info(&self) -> PoolInfo {
         PoolInfo {
             new_len: self.inner.new.len(),
             idle_len: self.inner.idle.len(),


### PR DESCRIPTION
Make pool info public so we don't have to parse a debug string to get that info.