### PR TITLE
Add Nothing type support to SqlType

### DIFF
--- a/src/types/column/bigint.rs
+++ b/src/types/column/bigint.rs
@@ -1,0 +1,133 @@
+use chrono_tz::Tz;
+
+use crate::{
+    binary::{Encoder, ReadEx},
+    errors::Result,
+    types::{SqlType, Value, ValueRef},
+};
+
+use super::column_data::{BoxColumnData, ColumnData};
+
+const BYTES_PER_VALUE: usize = 32;
+
+/// Column data for ClickHouse's Int256 type (32-byte little-endian signed integer).
+pub(crate) struct Int256ColumnData {
+    data: Vec<u8>,
+}
+
+impl Int256ColumnData {
+    pub(crate) fn load<R: ReadEx>(reader: &mut R, size: usize) -> Result<Self> {
+        let total_bytes = size * BYTES_PER_VALUE;
+        let mut data = vec![0u8; total_bytes];
+        reader.read_bytes(&mut data)?;
+        Ok(Int256ColumnData { data })
+    }
+
+    pub(crate) fn with_capacity(capacity: usize) -> Self {
+        Int256ColumnData {
+            data: Vec::with_capacity(capacity * BYTES_PER_VALUE),
+        }
+    }
+}
+
+impl ColumnData for Int256ColumnData {
+    fn sql_type(&self) -> SqlType {
+        SqlType::Int256
+    }
+
+    fn save(&self, encoder: &mut Encoder, start: usize, end: usize) {
+        let start_byte = start * BYTES_PER_VALUE;
+        let end_byte = end * BYTES_PER_VALUE;
+        encoder.write_bytes(&self.data[start_byte..end_byte]);
+    }
+
+    fn len(&self) -> usize {
+        self.data.len() / BYTES_PER_VALUE
+    }
+
+    fn push(&mut self, value: Value) {
+        if let Value::Int256(bytes) = value {
+            self.data.extend_from_slice(&bytes);
+        } else {
+            panic!("expected Int256 value");
+        }
+    }
+
+    fn at(&self, index: usize) -> ValueRef {
+        let start = index * BYTES_PER_VALUE;
+        let mut bytes = [0u8; BYTES_PER_VALUE];
+        bytes.copy_from_slice(&self.data[start..start + BYTES_PER_VALUE]);
+        ValueRef::Int256(bytes)
+    }
+
+    fn clone_instance(&self) -> BoxColumnData {
+        Box::new(Int256ColumnData {
+            data: self.data.clone(),
+        })
+    }
+
+    fn get_timezone(&self) -> Option<Tz> {
+        None
+    }
+}
+
+/// Column data for ClickHouse's UInt256 type (32-byte little-endian unsigned integer).
+pub(crate) struct UInt256ColumnData {
+    data: Vec<u8>,
+}
+
+impl UInt256ColumnData {
+    pub(crate) fn load<R: ReadEx>(reader: &mut R, size: usize) -> Result<Self> {
+        let total_bytes = size * BYTES_PER_VALUE;
+        let mut data = vec![0u8; total_bytes];
+        reader.read_bytes(&mut data)?;
+        Ok(UInt256ColumnData { data })
+    }
+
+    pub(crate) fn with_capacity(capacity: usize) -> Self {
+        UInt256ColumnData {
+            data: Vec::with_capacity(capacity * BYTES_PER_VALUE),
+        }
+    }
+}
+
+impl ColumnData for UInt256ColumnData {
+    fn sql_type(&self) -> SqlType {
+        SqlType::UInt256
+    }
+
+    fn save(&self, encoder: &mut Encoder, start: usize, end: usize) {
+        let start_byte = start * BYTES_PER_VALUE;
+        let end_byte = end * BYTES_PER_VALUE;
+        encoder.write_bytes(&self.data[start_byte..end_byte]);
+    }
+
+    fn len(&self) -> usize {
+        self.data.len() / BYTES_PER_VALUE
+    }
+
+    fn push(&mut self, value: Value) {
+        if let Value::UInt256(bytes) = value {
+            self.data.extend_from_slice(&bytes);
+        } else {
+            panic!("expected UInt256 value");
+        }
+    }
+
+    fn at(&self, index: usize) -> ValueRef {
+        let start = index * BYTES_PER_VALUE;
+        let mut bytes = [0u8; BYTES_PER_VALUE];
+        bytes.copy_from_slice(&self.data[start..start + BYTES_PER_VALUE]);
+        ValueRef::UInt256(bytes)
+    }
+
+    fn clone_instance(&self) -> BoxColumnData {
+        Box::new(UInt256ColumnData {
+            data: self.data.clone(),
+        })
+    }
+
+    fn get_timezone(&self) -> Option<Tz> {
+        None
+    }
+}

--- a/src/types/column/date32.rs
+++ b/src/types/column/date32.rs
@@ -1,0 +1,71 @@
+use chrono_tz::Tz;
+
+use crate::{
+    binary::{Encoder, ReadEx},
+    errors::Result,
+    types::{
+        column::{column_data::BoxColumnData, list::List, numeric::save_data, ColumnData},
+        SqlType, Value, ValueRef,
+    },
+};
+
+/// Column data for ClickHouse's Date32 type.
+///
+/// Date32 stores dates as a signed 32-bit integer representing the number of days
+/// since 1970-01-01 (Unix epoch). Supports range from 1900-01-01 to 2299-12-31.
+pub(crate) struct Date32ColumnData {
+    data: List<i32>,
+}
+
+impl Date32ColumnData {
+    pub(crate) fn load<R: ReadEx>(reader: &mut R, size: usize) -> Result<Self> {
+        let mut data = List::with_capacity(size);
+        unsafe {
+            data.set_len(size);
+        }
+        reader.read_bytes(data.as_mut())?;
+        Ok(Date32ColumnData { data })
+    }
+
+    pub(crate) fn with_capacity(capacity: usize) -> Self {
+        Date32ColumnData {
+            data: List::with_capacity(capacity),
+        }
+    }
+}
+
+impl ColumnData for Date32ColumnData {
+    fn sql_type(&self) -> SqlType {
+        SqlType::Date32
+    }
+
+    fn save(&self, encoder: &mut Encoder, start: usize, end: usize) {
+        save_data::<i32>(self.data.as_ref(), encoder, start, end);
+    }
+
+    fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    fn push(&mut self, value: Value) {
+        if let Value::Date32(days) = value {
+            self.data.push(days);
+        } else {
+            panic!("expected Date32 value");
+        }
+    }
+
+    fn at(&self, index: usize) -> ValueRef {
+        ValueRef::Date32(self.data.at(index))
+    }
+
+    fn clone_instance(&self) -> BoxColumnData {
+        Box::new(Date32ColumnData {
+            data: self.data.clone(),
+        })
+    }
+
+    fn get_timezone(&self) -> Option<Tz> {
+        None
+    }
+}

--- a/src/types/column/factory.rs
+++ b/src/types/column/factory.rs
@@ -25,11 +25,14 @@ use crate::{
             list::List,
             low_cardinality::LowCardinalityColumnData,
             map::MapColumnData,
+            bigint::{Int256ColumnData, UInt256ColumnData},
+            date32::Date32ColumnData,
             nothing::NothingColumnData,
             nullable::NullableColumnData,
             numeric::VectorColumnData,
             simple_agg_func::SimpleAggregateFunctionColumnData,
             string::StringColumnData,
+            tuple::TupleColumnData,
             ArcColumnWrapper, BoxColumnWrapper, ColumnWrapper,
         },
         decimal::NoBits,
@@ -82,6 +85,9 @@ impl dyn ColumnData {
             "IPv6" => W::wrap(IpColumnData::<Ipv6>::load(reader, size)?),
             "UUID" => W::wrap(IpColumnData::<Uuid>::load(reader, size)?),
             "Nothing" => W::wrap(NothingColumnData::load(reader, size)?),
+            "Int256" => W::wrap(Int256ColumnData::load(reader, size)?),
+            "UInt256" => W::wrap(UInt256ColumnData::load(reader, size)?),
+            "Date32" => W::wrap(Date32ColumnData::load(reader, size)?),
             _ => {
                 if let Some(inner_type) = parse_nullable_type(type_name) {
                     W::wrap(NullableColumnData::load(reader, inner_type, size, tz)?)
@@ -109,6 +115,8 @@ impl dyn ColumnData {
                     W::wrap(SimpleAggregateFunctionColumnData::load(reader, func, inner_type, size, tz)?)
                 } else if let Some(inner_type) = parse_low_cardinality(type_name) {
                     W::wrap(LowCardinalityColumnData::load(reader, inner_type, size, tz)?)
+                } else if let Some(inner_types) = parse_tuple_type(type_name) {
+                    W::wrap(TupleColumnData::load(reader, inner_types, size, tz)?)
                 } else {
                     let message = format!("Unsupported column type \"{type_name}\".");
                     return Err(message.into());
@@ -242,6 +250,12 @@ impl dyn ColumnData {
                 )
             }
             SqlType::Nothing => W::wrap(NothingColumnData::with_capacity(capacity)),
+            SqlType::Int256 => W::wrap(Int256ColumnData::with_capacity(capacity)),
+            SqlType::UInt256 => W::wrap(UInt256ColumnData::with_capacity(capacity)),
+            SqlType::Date32 => W::wrap(Date32ColumnData::with_capacity(capacity)),
+            SqlType::Tuple(ref types) => {
+                W::wrap(TupleColumnData::with_capacity(types, timezone, capacity)?)
+            }
         })
     }
 }
@@ -544,6 +558,47 @@ fn parse_low_cardinality(source: &str) -> Option<&str> {
     Some(source[lo + 1..hi].trim())
 }
 
+/// Parse a Tuple type string like "Tuple(UInt8, String, Nullable(Int32))"
+/// Returns a vector of the inner type name strings.
+fn parse_tuple_type(source: &str) -> Option<Vec<&str>> {
+    let trimmed = source.trim();
+    if !trimmed.starts_with("Tuple(") || !trimmed.ends_with(')') {
+        return None;
+    }
+
+    let inner = &trimmed[6..trimmed.len() - 1];
+    let mut types = Vec::new();
+    let mut depth = 0;
+    let mut start = 0;
+
+    for (i, ch) in inner.char_indices() {
+        match ch {
+            '(' => depth += 1,
+            ')' => depth -= 1,
+            ',' if depth == 0 => {
+                let t = inner[start..i].trim();
+                if !t.is_empty() {
+                    types.push(t);
+                }
+                start = i + 1;
+            }
+            _ => {}
+        }
+    }
+
+    // Last element
+    let t = inner[start..].trim();
+    if !t.is_empty() {
+        types.push(t);
+    }
+
+    if types.is_empty() {
+        None
+    } else {
+        Some(types)
+    }
+}
+
 fn get_timezone(timezone: &Option<String>, tz: Tz) -> Result<Tz> {
     match timezone {
         None => Ok(tz),
@@ -833,5 +888,152 @@ mod test {
         .unwrap();
         assert_eq!(column.sql_type(), SqlType::Nothing);
         assert_eq!(column.len(), 0);
+    }
+
+    #[test]
+    fn test_load_int256_column() {
+        use crate::types::ValueRef;
+        // 2 rows of Int256, each 32 bytes (little-endian)
+        let mut data = vec![0u8; 64];
+        data[0] = 42; // first value = 42
+        data[32] = 7; // second value = 7
+        let mut cursor = std::io::Cursor::new(data);
+        let tz: Tz = "UTC".parse().unwrap();
+        let column = <dyn ColumnData>::load_data::<ArcColumnWrapper, _>(
+            &mut cursor, "Int256", 2, tz,
+        ).unwrap();
+        assert_eq!(column.len(), 2);
+        assert_eq!(column.sql_type(), SqlType::Int256);
+        if let ValueRef::Int256(bytes) = column.at(0) {
+            assert_eq!(bytes[0], 42);
+        } else {
+            panic!("Expected Int256");
+        }
+    }
+
+    #[test]
+    fn test_load_uint256_column() {
+        let mut data = vec![0u8; 32];
+        data[0] = 255;
+        let mut cursor = std::io::Cursor::new(data);
+        let tz: Tz = "UTC".parse().unwrap();
+        let column = <dyn ColumnData>::load_data::<ArcColumnWrapper, _>(
+            &mut cursor, "UInt256", 1, tz,
+        ).unwrap();
+        assert_eq!(column.len(), 1);
+        assert_eq!(column.sql_type(), SqlType::UInt256);
+    }
+
+    #[test]
+    fn test_load_date32_column() {
+        use crate::types::ValueRef;
+        // Date32 is i32 little-endian. 19000 days from epoch ≈ 2022-01-06
+        let days: i32 = 19000;
+        let data = days.to_le_bytes().to_vec();
+        let mut cursor = std::io::Cursor::new(data);
+        let tz: Tz = "UTC".parse().unwrap();
+        let column = <dyn ColumnData>::load_data::<ArcColumnWrapper, _>(
+            &mut cursor, "Date32", 1, tz,
+        ).unwrap();
+        assert_eq!(column.len(), 1);
+        assert_eq!(column.sql_type(), SqlType::Date32);
+        if let ValueRef::Date32(v) = column.at(0) {
+            assert_eq!(v, 19000);
+        } else {
+            panic!("Expected Date32");
+        }
+    }
+
+    #[test]
+    fn test_parse_tuple_type_simple() {
+        assert_eq!(
+            parse_tuple_type("Tuple(UInt8, String)"),
+            Some(vec!["UInt8", "String"])
+        );
+    }
+
+    #[test]
+    fn test_parse_tuple_type_nested() {
+        assert_eq!(
+            parse_tuple_type("Tuple(UInt8, Nullable(Int32), Array(String))"),
+            Some(vec!["UInt8", "Nullable(Int32)", "Array(String)"])
+        );
+    }
+
+    #[test]
+    fn test_parse_tuple_type_not_tuple() {
+        assert_eq!(parse_tuple_type("Array(UInt8)"), None);
+    }
+
+    #[test]
+    fn test_load_tuple_column() {
+        use crate::types::ValueRef;
+        // Tuple(UInt8, UInt8) with 2 rows
+        // Column 1 (UInt8): [10, 20]
+        // Column 2 (UInt8): [30, 40]
+        let data: Vec<u8> = vec![10, 20, 30, 40];
+        let mut cursor = std::io::Cursor::new(data);
+        let tz: Tz = "UTC".parse().unwrap();
+        let column = <dyn ColumnData>::load_data::<ArcColumnWrapper, _>(
+            &mut cursor, "Tuple(UInt8, UInt8)", 2, tz,
+        ).unwrap();
+        assert_eq!(column.len(), 2);
+
+        // First row: (10, 30)
+        if let ValueRef::Tuple(vs) = column.at(0) {
+            assert_eq!(vs.len(), 2);
+            assert_eq!(vs[0], ValueRef::UInt8(10));
+            assert_eq!(vs[1], ValueRef::UInt8(30));
+        } else {
+            panic!("Expected Tuple");
+        }
+
+        // Second row: (20, 40)
+        if let ValueRef::Tuple(vs) = column.at(1) {
+            assert_eq!(vs[0], ValueRef::UInt8(20));
+            assert_eq!(vs[1], ValueRef::UInt8(40));
+        } else {
+            panic!("Expected Tuple");
+        }
+    }
+
+    #[test]
+    fn test_int256_from_type() {
+        let tz: Tz = "UTC".parse().unwrap();
+        let column = <dyn ColumnData>::from_type::<ArcColumnWrapper>(
+            SqlType::Int256, tz, 5,
+        ).unwrap();
+        assert_eq!(column.sql_type(), SqlType::Int256);
+    }
+
+    #[test]
+    fn test_uint256_from_type() {
+        let tz: Tz = "UTC".parse().unwrap();
+        let column = <dyn ColumnData>::from_type::<ArcColumnWrapper>(
+            SqlType::UInt256, tz, 5,
+        ).unwrap();
+        assert_eq!(column.sql_type(), SqlType::UInt256);
+    }
+
+    #[test]
+    fn test_date32_from_type() {
+        let tz: Tz = "UTC".parse().unwrap();
+        let column = <dyn ColumnData>::from_type::<ArcColumnWrapper>(
+            SqlType::Date32, tz, 5,
+        ).unwrap();
+        assert_eq!(column.sql_type(), SqlType::Date32);
+    }
+
+    #[test]
+    fn test_tuple_from_type() {
+        let tz: Tz = "UTC".parse().unwrap();
+        let types: Vec<&'static SqlType> = vec![&SqlType::UInt8, &SqlType::String];
+        let column = <dyn ColumnData>::from_type::<ArcColumnWrapper>(
+            SqlType::Tuple(types), tz, 5,
+        ).unwrap();
+        assert_eq!(
+            column.sql_type(),
+            SqlType::Tuple(vec![&SqlType::UInt8, &SqlType::String])
+        );
     }
 }

--- a/src/types/column/factory.rs
+++ b/src/types/column/factory.rs
@@ -778,4 +778,60 @@ mod test {
             Some("String")
         );
     }
+
+    #[test]
+    fn test_load_nothing_column() {
+        let mut cursor = std::io::Cursor::new(Vec::<u8>::new());
+        let tz: Tz = "UTC".parse().unwrap();
+        let column = <dyn ColumnData>::load_data::<ArcColumnWrapper, _>(
+            &mut cursor,
+            "Nothing",
+            3,
+            tz,
+        )
+        .unwrap();
+        assert_eq!(column.len(), 3);
+        assert_eq!(column.sql_type(), SqlType::Nothing);
+    }
+
+    #[test]
+    fn test_load_nullable_nothing_column() {
+        use crate::types::ValueRef;
+        // Nullable(Nothing) has 3 rows, all null: null bitmap = [1, 1, 1], inner = Nothing (0 bytes)
+        let data: Vec<u8> = vec![1, 1, 1];
+        let mut cursor = std::io::Cursor::new(data);
+        let tz: Tz = "UTC".parse().unwrap();
+        let column = <dyn ColumnData>::load_data::<ArcColumnWrapper, _>(
+            &mut cursor,
+            "Nullable(Nothing)",
+            3,
+            tz,
+        )
+        .unwrap();
+        assert_eq!(column.len(), 3);
+        assert_eq!(
+            column.sql_type(),
+            SqlType::Nullable(&SqlType::Nothing)
+        );
+        // All values should be null
+        for i in 0..3 {
+            match column.at(i) {
+                ValueRef::Nullable(either) => assert!(either.is_left()),
+                other => panic!("Expected Nullable, got {:?}", other),
+            }
+        }
+    }
+
+    #[test]
+    fn test_nothing_from_type() {
+        let tz: Tz = "UTC".parse().unwrap();
+        let column = <dyn ColumnData>::from_type::<ArcColumnWrapper>(
+            SqlType::Nothing,
+            tz,
+            5,
+        )
+        .unwrap();
+        assert_eq!(column.sql_type(), SqlType::Nothing);
+        assert_eq!(column.len(), 0);
+    }
 }

--- a/src/types/column/factory.rs
+++ b/src/types/column/factory.rs
@@ -25,6 +25,7 @@ use crate::{
             list::List,
             low_cardinality::LowCardinalityColumnData,
             map::MapColumnData,
+            nothing::NothingColumnData,
             nullable::NullableColumnData,
             numeric::VectorColumnData,
             simple_agg_func::SimpleAggregateFunctionColumnData,
@@ -80,6 +81,7 @@ impl dyn ColumnData {
             "IPv4" => W::wrap(IpColumnData::<Ipv4>::load(reader, size)?),
             "IPv6" => W::wrap(IpColumnData::<Ipv6>::load(reader, size)?),
             "UUID" => W::wrap(IpColumnData::<Uuid>::load(reader, size)?),
+            "Nothing" => W::wrap(NothingColumnData::load(reader, size)?),
             _ => {
                 if let Some(inner_type) = parse_nullable_type(type_name) {
                     W::wrap(NullableColumnData::load(reader, inner_type, size, tz)?)
@@ -239,6 +241,7 @@ impl dyn ColumnData {
                                                                                  // }
                 )
             }
+            SqlType::Nothing => W::wrap(NothingColumnData::with_capacity(capacity)),
         })
     }
 }

--- a/src/types/column/factory.rs
+++ b/src/types/column/factory.rs
@@ -559,6 +559,7 @@ fn parse_low_cardinality(source: &str) -> Option<&str> {
 }
 
 /// Parse a Tuple type string like "Tuple(UInt8, String, Nullable(Int32))"
+/// Also handles named tuples like "Tuple(a UInt8, b String)" by stripping names.
 /// Returns a vector of the inner type name strings.
 fn parse_tuple_type(source: &str) -> Option<Vec<&str>> {
     let trimmed = source.trim();
@@ -576,7 +577,7 @@ fn parse_tuple_type(source: &str) -> Option<Vec<&str>> {
             '(' => depth += 1,
             ')' => depth -= 1,
             ',' if depth == 0 => {
-                let t = inner[start..i].trim();
+                let t = strip_tuple_element_name(inner[start..i].trim());
                 if !t.is_empty() {
                     types.push(t);
                 }
@@ -587,16 +588,41 @@ fn parse_tuple_type(source: &str) -> Option<Vec<&str>> {
     }
 
     // Last element
-    let t = inner[start..].trim();
+    let t = strip_tuple_element_name(inner[start..].trim());
     if !t.is_empty() {
         types.push(t);
     }
 
     if types.is_empty() {
+        // Empty Tuple() is valid in ClickHouse but not currently supported.
+        // Returns None to surface an 'unsupported type' error from load_data.
         None
     } else {
         Some(types)
     }
+}
+
+/// Strip optional element name from a named tuple element.
+/// e.g. "a UInt8" -> "UInt8", "Nullable(Int32)" -> "Nullable(Int32)"
+fn strip_tuple_element_name(element: &str) -> &str {
+    // Named elements have the form "name Type" where name is an identifier
+    // and Type starts with an uppercase letter or is a known type.
+    // We detect this by finding a space that's not inside parentheses.
+    let mut depth = 0;
+    for (i, ch) in element.char_indices() {
+        match ch {
+            '(' => depth += 1,
+            ')' => depth -= 1,
+            ' ' if depth == 0 => {
+                let rest = element[i + 1..].trim();
+                if !rest.is_empty() {
+                    return rest;
+                }
+            }
+            _ => {}
+        }
+    }
+    element
 }
 
 fn get_timezone(timezone: &Option<String>, tz: Tz) -> Result<Tz> {
@@ -961,8 +987,29 @@ mod test {
     }
 
     #[test]
+    fn test_parse_tuple_type_named() {
+        assert_eq!(
+            parse_tuple_type("Tuple(a UInt8, b String)"),
+            Some(vec!["UInt8", "String"])
+        );
+    }
+
+    #[test]
+    fn test_parse_tuple_type_named_nested() {
+        assert_eq!(
+            parse_tuple_type("Tuple(id UInt64, name Nullable(String))"),
+            Some(vec!["UInt64", "Nullable(String)"])
+        );
+    }
+
+    #[test]
     fn test_parse_tuple_type_not_tuple() {
         assert_eq!(parse_tuple_type("Array(UInt8)"), None);
+    }
+
+    #[test]
+    fn test_parse_tuple_type_empty() {
+        assert_eq!(parse_tuple_type("Tuple()"), None);
     }
 
     #[test]

--- a/src/types/column/mod.rs
+++ b/src/types/column/mod.rs
@@ -32,11 +32,13 @@ pub(crate) use self::{column_data::ColumnData, string_pool::StringPool};
 pub use self::{concat::ConcatColumnData, numeric::VectorColumnData};
 
 mod array;
+mod bigint;
 pub(crate) mod chrono_datetime;
 mod chunk;
 mod column_data;
 mod concat;
 mod date;
+mod date32;
 pub(crate) mod datetime64;
 mod decimal;
 mod enums;
@@ -53,6 +55,7 @@ mod numeric;
 mod simple_agg_func;
 mod string;
 mod string_pool;
+mod tuple;
 mod util;
 
 /// Represents Clickhouse Column

--- a/src/types/column/mod.rs
+++ b/src/types/column/mod.rs
@@ -47,6 +47,7 @@ pub mod iter;
 mod list;
 mod low_cardinality;
 mod map;
+mod nothing;
 mod nullable;
 mod numeric;
 mod simple_agg_func;

--- a/src/types/column/nothing.rs
+++ b/src/types/column/nothing.rs
@@ -1,0 +1,58 @@
+use chrono_tz::Tz;
+
+use crate::{
+    binary::{Encoder, ReadEx},
+    errors::Result,
+    types::{SqlType, Value, ValueRef},
+};
+
+use super::column_data::{BoxColumnData, ColumnData};
+
+/// Column data for ClickHouse's `Nothing` type.
+///
+/// The `Nothing` type has no values and zero bytes per row.
+/// It is primarily used as `Nullable(Nothing)` to represent columns of all NULLs.
+pub(crate) struct NothingColumnData {
+    pub(crate) len: usize,
+}
+
+impl NothingColumnData {
+    pub(crate) fn load<R: ReadEx>(_reader: &mut R, size: usize) -> Result<Self> {
+        // Nothing type has zero bytes per value, so we don't read anything
+        Ok(NothingColumnData { len: size })
+    }
+
+    pub(crate) fn with_capacity(_capacity: usize) -> Self {
+        NothingColumnData { len: 0 }
+    }
+}
+
+impl ColumnData for NothingColumnData {
+    fn sql_type(&self) -> SqlType {
+        SqlType::Nothing
+    }
+
+    fn save(&self, _encoder: &mut Encoder, _start: usize, _end: usize) {
+        // Nothing type has zero bytes per value, nothing to write
+    }
+
+    fn len(&self) -> usize {
+        self.len
+    }
+
+    fn push(&mut self, _value: Value) {
+        self.len += 1;
+    }
+
+    fn at(&self, _index: usize) -> ValueRef {
+        ValueRef::Nullable(either::Either::Left(&SqlType::Nothing))
+    }
+
+    fn clone_instance(&self) -> BoxColumnData {
+        Box::new(NothingColumnData { len: self.len })
+    }
+
+    fn get_timezone(&self) -> Option<Tz> {
+        None
+    }
+}

--- a/src/types/column/nothing.rs
+++ b/src/types/column/nothing.rs
@@ -8,10 +8,15 @@ use crate::{
 
 use super::column_data::{BoxColumnData, ColumnData};
 
-/// Column data for ClickHouse's `Nothing` type.
+/// Column data for ClickHouse's `Nothing` type: zero bytes per row, used almost
+/// exclusively inside `Nullable(Nothing)` for all-NULL columns.
 ///
-/// The `Nothing` type has no values and zero bytes per row.
-/// It is primarily used as `Nullable(Nothing)` to represent columns of all NULLs.
+/// Design note: since there's no `ValueRef::Nothing` variant, `at()` returns a
+/// Nullable sentinel (`Nullable(Left(&SqlType::Nothing))`). This means standalone
+/// Nothing columns have slightly unusual semantics — the `SqlType::Nothing` →
+/// `Value::default()` → `SqlType::from()` roundtrip produces `Nullable(Nothing)`
+/// instead of `Nothing`. This is an acceptable tradeoff given the type's narrow
+/// real-world use case (always wrapped in Nullable).
 pub(crate) struct NothingColumnData {
     pub(crate) len: usize,
 }
@@ -44,7 +49,8 @@ impl ColumnData for NothingColumnData {
         self.len += 1;
     }
 
-    fn at(&self, _index: usize) -> ValueRef {
+    fn at(&self, index: usize) -> ValueRef {
+        assert!(index < self.len, "index out of bounds: {} >= {}", index, self.len);
         ValueRef::Nullable(either::Either::Left(&SqlType::Nothing))
     }
 

--- a/src/types/column/tuple.rs
+++ b/src/types/column/tuple.rs
@@ -1,0 +1,115 @@
+use std::sync::Arc;
+
+use chrono_tz::Tz;
+
+use crate::{
+    binary::{Encoder, ReadEx},
+    errors::Result,
+    types::{
+        column::{
+            column_data::{ArcColumnData, BoxColumnData},
+            ArcColumnWrapper, ColumnData, ColumnWrapper,
+        },
+        SqlType, Value, ValueRef,
+    },
+};
+
+/// Column data for ClickHouse's Tuple(T1, T2, ..., TN) type.
+///
+/// Each element of the tuple is stored as a separate sub-column (columnar layout).
+/// For a Tuple(UInt8, String) with N rows, we store one UInt8 column of N rows
+/// and one String column of N rows.
+pub(crate) struct TupleColumnData {
+    pub(crate) columns: Vec<ArcColumnData>,
+}
+
+impl TupleColumnData {
+    pub(crate) fn load<R: ReadEx>(
+        reader: &mut R,
+        type_names: Vec<&str>,
+        rows: usize,
+        tz: Tz,
+    ) -> Result<Self> {
+        let mut columns = Vec::with_capacity(type_names.len());
+        for type_name in type_names {
+            let column =
+                <dyn ColumnData>::load_data::<ArcColumnWrapper, _>(reader, type_name, rows, tz)?;
+            columns.push(column);
+        }
+        Ok(TupleColumnData { columns })
+    }
+
+    pub(crate) fn with_capacity(
+        element_types: &[&'static SqlType],
+        tz: Tz,
+        capacity: usize,
+    ) -> Result<Self> {
+        let mut columns = Vec::with_capacity(element_types.len());
+        for sql_type in element_types {
+            let column = <dyn ColumnData>::from_type::<ArcColumnWrapper>(
+                (*sql_type).clone(),
+                tz,
+                capacity,
+            )?;
+            columns.push(column);
+        }
+        Ok(TupleColumnData { columns })
+    }
+}
+
+impl ColumnData for TupleColumnData {
+    fn sql_type(&self) -> SqlType {
+        let types: Vec<&'static SqlType> = self
+            .columns
+            .iter()
+            .map(|c| {
+                let sql_type = c.sql_type();
+                let static_ref: &'static SqlType = sql_type.into();
+                static_ref
+            })
+            .collect();
+        SqlType::Tuple(types)
+    }
+
+    fn save(&self, encoder: &mut Encoder, start: usize, end: usize) {
+        for column in &self.columns {
+            column.save(encoder, start, end);
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.columns.first().map_or(0, |c| c.len())
+    }
+
+    fn push(&mut self, value: Value) {
+        if let Value::Tuple(values) = value {
+            assert_eq!(
+                values.len(),
+                self.columns.len(),
+                "tuple value length mismatch"
+            );
+            for (i, v) in values.iter().enumerate() {
+                Arc::get_mut(&mut self.columns[i])
+                    .unwrap()
+                    .push(v.clone());
+            }
+        } else {
+            panic!("expected Tuple value");
+        }
+    }
+
+    fn at(&self, index: usize) -> ValueRef {
+        let values: Vec<ValueRef> = self.columns.iter().map(|c| c.at(index)).collect();
+        ValueRef::Tuple(Arc::new(values))
+    }
+
+    fn clone_instance(&self) -> BoxColumnData {
+        Box::new(TupleColumnData {
+            columns: self.columns.clone(),
+        })
+    }
+
+    fn get_timezone(&self) -> Option<Tz> {
+        self.columns.first().and_then(|c| c.get_timezone())
+    }
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -340,6 +340,10 @@ pub enum SqlType {
     SimpleAggregateFunction(SimpleAggFunc, &'static SqlType),
     Map(&'static SqlType, &'static SqlType),
     Nothing,
+    Int256,
+    UInt256,
+    Date32,
+    Tuple(Vec<&'static SqlType>),
 }
 
 lazy_static! {
@@ -446,6 +450,14 @@ impl SqlType {
             }
             SqlType::Map(k, v) => format!("Map({}, {})", &k, &v).into(),
             SqlType::Nothing => "Nothing".into(),
+            SqlType::Int256 => "Int256".into(),
+            SqlType::UInt256 => "UInt256".into(),
+            SqlType::Date32 => "Date32".into(),
+            SqlType::Tuple(ref types) => {
+                let inner: Vec<std::borrow::Cow<'static, str>> = types.iter().map(|t| SqlType::to_string(t)).collect();
+                let strs: Vec<&str> = inner.iter().map(|s| s.as_ref()).collect();
+                format!("Tuple({})", strs.join(", ")).into()
+            }
         }
     }
 
@@ -500,4 +512,31 @@ fn test_nullable_nothing_display() {
         format!("{}", SqlType::Nullable(&SqlType::Nothing)),
         "Nullable(Nothing)"
     );
+}
+
+#[test]
+fn test_int256_display() {
+    assert_eq!(format!("{}", SqlType::Int256), "Int256");
+}
+
+#[test]
+fn test_uint256_display() {
+    assert_eq!(format!("{}", SqlType::UInt256), "UInt256");
+}
+
+#[test]
+fn test_date32_display() {
+    assert_eq!(format!("{}", SqlType::Date32), "Date32");
+}
+
+#[test]
+fn test_tuple_display() {
+    let t = SqlType::Tuple(vec![&SqlType::UInt8, &SqlType::String]);
+    assert_eq!(format!("{}", t), "Tuple(UInt8, String)");
+}
+
+#[test]
+fn test_nested_tuple_display() {
+    let t = SqlType::Tuple(vec![&SqlType::UInt8, &SqlType::Nullable(&SqlType::Int32)]);
+    assert_eq!(format!("{}", t), "Tuple(UInt8, Nullable(Int32))");
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -488,3 +488,16 @@ fn test_to_string() {
     let actual = SqlType::Nullable(&SqlType::UInt8).to_string();
     assert_eq!(expected, actual)
 }
+
+#[test]
+fn test_nothing_display() {
+    assert_eq!(format!("{}", SqlType::Nothing), "Nothing");
+}
+
+#[test]
+fn test_nullable_nothing_display() {
+    assert_eq!(
+        format!("{}", SqlType::Nullable(&SqlType::Nothing)),
+        "Nullable(Nothing)"
+    );
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -339,6 +339,7 @@ pub enum SqlType {
     Enum16(Vec<(String, i16)>),
     SimpleAggregateFunction(SimpleAggFunc, &'static SqlType),
     Map(&'static SqlType, &'static SqlType),
+    Nothing,
 }
 
 lazy_static! {
@@ -444,6 +445,7 @@ impl SqlType {
                 format!("Enum16({})", a.join(",")).into()
             }
             SqlType::Map(k, v) => format!("Map({}, {})", &k, &v).into(),
+            SqlType::Nothing => "Nothing".into(),
         }
     }
 

--- a/src/types/value.rs
+++ b/src/types/value.rs
@@ -187,6 +187,7 @@ impl Value {
             SqlType::Enum8(values) => Value::Enum8(values, Enum8(0)),
             SqlType::Enum16(values) => Value::Enum16(values, Enum16(0)),
             SqlType::Map(k, v) => Value::Map(k, v, Arc::new(HashMap::default())),
+            SqlType::Nothing => Value::Nullable(Either::Left(&SqlType::Nothing)),
         }
     }
 }

--- a/src/types/value.rs
+++ b/src/types/value.rs
@@ -82,6 +82,7 @@ impl Hash for Value {
             Self::Date32(d) => d.hash(state),
             Self::DateTime(t, _) => t.hash(state),
             Self::DateTime64(t, (prec_a, _)) => (*t, *prec_a).hash(state),
+            Self::Tuple(ref vs) => vs.hash(state),
             _ => unimplemented!(),
         }
     }
@@ -295,9 +296,11 @@ impl fmt::Display for Value {
             Value::UInt256(ref v) => write!(f, "{:?}", v),
             Value::Date32(ref v) => {
                 let date = NaiveDate::from_ymd_opt(1970, 1, 1)
-                    .map(|unix_epoch| unix_epoch + Duration::days(i64::from(*v)))
-                    .unwrap();
-                fmt::Display::fmt(&date.format("%Y-%m-%d"), f)
+                    .and_then(|epoch| epoch.checked_add_signed(Duration::days(i64::from(*v))));
+                match date {
+                    Some(d) => fmt::Display::fmt(&d.format("%Y-%m-%d"), f),
+                    None => write!(f, "Date32({})", v),
+                }
             }
             Value::Tuple(ref vs) => {
                 let cells: Vec<String> = vs.iter().map(|v| format!("{v}")).collect();

--- a/src/types/value.rs
+++ b/src/types/value.rs
@@ -56,6 +56,10 @@ pub enum Value {
         &'static SqlType,
         Arc<HashMap<Value, Value>>,
     ),
+    Int256([u8; 32]),
+    UInt256([u8; 32]),
+    Date32(i32),
+    Tuple(Arc<Vec<Value>>),
 }
 
 impl Hash for Value {
@@ -72,7 +76,10 @@ impl Hash for Value {
             Self::UInt32(i) => i.hash(state),
             Self::UInt64(i) => i.hash(state),
             Self::UInt128(i) => i.hash(state),
+            Self::Int256(i) => i.hash(state),
+            Self::UInt256(i) => i.hash(state),
             Self::Date(d) => d.hash(state),
+            Self::Date32(d) => d.hash(state),
             Self::DateTime(t, _) => t.hash(state),
             Self::DateTime64(t, (prec_a, _)) => (*t, *prec_a).hash(state),
             _ => unimplemented!(),
@@ -118,6 +125,10 @@ impl PartialEq for Value {
             (Value::Ipv4(a), Value::Ipv4(b)) => *a == *b,
             (Value::Ipv6(a), Value::Ipv6(b)) => *a == *b,
             (Value::Uuid(a), Value::Uuid(b)) => *a == *b,
+            (Value::Int256(a), Value::Int256(b)) => *a == *b,
+            (Value::UInt256(a), Value::UInt256(b)) => *a == *b,
+            (Value::Date32(a), Value::Date32(b)) => *a == *b,
+            (Value::Tuple(a), Value::Tuple(b)) => *a == *b,
             (Value::DateTime64(a, (prec_a, tz_a)), Value::DateTime64(b, (prec_b, tz_b))) => {
                 // chrono has no "variable-precision" offset method. As a
                 // fallback, we always use `timestamp_nanos` and multiply by
@@ -188,6 +199,13 @@ impl Value {
             SqlType::Enum16(values) => Value::Enum16(values, Enum16(0)),
             SqlType::Map(k, v) => Value::Map(k, v, Arc::new(HashMap::default())),
             SqlType::Nothing => Value::Nullable(Either::Left(&SqlType::Nothing)),
+            SqlType::Int256 => Value::Int256([0; 32]),
+            SqlType::UInt256 => Value::UInt256([0; 32]),
+            SqlType::Date32 => Value::Date32(0),
+            SqlType::Tuple(ref types) => {
+                let values: Vec<Value> = types.iter().map(|t| Value::default((*t).clone())).collect();
+                Value::Tuple(Arc::new(values))
+            }
         }
     }
 }
@@ -273,6 +291,18 @@ impl fmt::Display for Value {
                     .collect();
                 write!(f, "[{}]", cells.join(", "))
             }
+            Value::Int256(ref v) => write!(f, "{:?}", v),
+            Value::UInt256(ref v) => write!(f, "{:?}", v),
+            Value::Date32(ref v) => {
+                let date = NaiveDate::from_ymd_opt(1970, 1, 1)
+                    .map(|unix_epoch| unix_epoch + Duration::days(i64::from(*v)))
+                    .unwrap();
+                fmt::Display::fmt(&date.format("%Y-%m-%d"), f)
+            }
+            Value::Tuple(ref vs) => {
+                let cells: Vec<String> = vs.iter().map(|v| format!("{v}")).collect();
+                write!(f, "({})", cells.join(", "))
+            }
         }
     }
 }
@@ -316,6 +346,17 @@ impl From<Value> for SqlType {
                 SqlType::DateTime(DateTimeType::DateTime64(precision, tz))
             }
             Value::Map(k, v, _) => SqlType::Map(k, v),
+            Value::Int256(_) => SqlType::Int256,
+            Value::UInt256(_) => SqlType::UInt256,
+            Value::Date32(_) => SqlType::Date32,
+            Value::Tuple(ref vs) => {
+                let types: Vec<&'static SqlType> = vs.iter().map(|v| {
+                    let sql_type = SqlType::from(v.clone());
+                    let static_ref: &'static SqlType = sql_type.into();
+                    static_ref
+                }).collect();
+                SqlType::Tuple(types)
+            }
         }
     }
 }

--- a/src/types/value.rs
+++ b/src/types/value.rs
@@ -851,4 +851,13 @@ mod test {
         assert_eq!(block.row_count(), 1);
         assert_eq!(block.column_count(), 9);
     }
+
+    #[test]
+    fn test_default_nothing() {
+        let value = Value::default(SqlType::Nothing);
+        match value {
+            Value::Nullable(either) => assert!(either.is_left()),
+            other => panic!("Expected Nullable(Left(...)), got {:?}", other),
+        }
+    }
 }

--- a/src/types/value_ref.rs
+++ b/src/types/value_ref.rs
@@ -76,6 +76,7 @@ impl<'a> Hash for ValueRef<'a> {
             Self::Int256(i) => i.hash(state),
             Self::UInt256(i) => i.hash(state),
             Self::Date32(d) => d.hash(state),
+            Self::Tuple(ref vs) => vs.hash(state),
             _ => unimplemented!(),
         }
     }
@@ -213,9 +214,11 @@ impl<'a> fmt::Display for ValueRef<'a> {
             ValueRef::UInt256(v) => write!(f, "{:?}", v),
             ValueRef::Date32(v) => {
                 let date = NaiveDate::from_ymd_opt(1970, 1, 1)
-                    .map(|unix_epoch| unix_epoch + Duration::days(i64::from(*v)))
-                    .unwrap();
-                fmt::Display::fmt(&date.format("%Y-%m-%d"), f)
+                    .and_then(|epoch| epoch.checked_add_signed(Duration::days(i64::from(*v))));
+                match date {
+                    Some(d) => fmt::Display::fmt(&d.format("%Y-%m-%d"), f),
+                    None => write!(f, "Date32({})", v),
+                }
             }
             ValueRef::Tuple(ref vs) => {
                 let cells: Vec<String> = vs.iter().map(|v| format!("{v}")).collect();

--- a/src/types/value_ref.rs
+++ b/src/types/value_ref.rs
@@ -53,6 +53,10 @@ pub enum ValueRef<'a> {
         &'static SqlType,
         Arc<HashMap<ValueRef<'a>, ValueRef<'a>>>,
     ),
+    Int256([u8; 32]),
+    UInt256([u8; 32]),
+    Date32(i32),
+    Tuple(Arc<Vec<ValueRef<'a>>>),
 }
 
 impl<'a> Hash for ValueRef<'a> {
@@ -69,6 +73,9 @@ impl<'a> Hash for ValueRef<'a> {
             Self::UInt32(i) => i.hash(state),
             Self::UInt64(i) => i.hash(state),
             Self::UInt128(i) => i.hash(state),
+            Self::Int256(i) => i.hash(state),
+            Self::UInt256(i) => i.hash(state),
+            Self::Date32(d) => d.hash(state),
             _ => unimplemented!(),
         }
     }
@@ -118,6 +125,10 @@ impl<'a> PartialEq for ValueRef<'a> {
                 }
                 map1 == map2
             }
+            (ValueRef::Int256(a), ValueRef::Int256(b)) => *a == *b,
+            (ValueRef::UInt256(a), ValueRef::UInt256(b)) => *a == *b,
+            (ValueRef::Date32(a), ValueRef::Date32(b)) => *a == *b,
+            (ValueRef::Tuple(a), ValueRef::Tuple(b)) => *a == *b,
             _ => false,
         }
     }
@@ -198,6 +209,18 @@ impl<'a> fmt::Display for ValueRef<'a> {
                 let cells: Vec<String> = vs.iter().map(|v| format!("{}-{}", v.0, v.1)).collect();
                 write!(f, "[{}]", cells.join(", "))
             }
+            ValueRef::Int256(v) => write!(f, "{:?}", v),
+            ValueRef::UInt256(v) => write!(f, "{:?}", v),
+            ValueRef::Date32(v) => {
+                let date = NaiveDate::from_ymd_opt(1970, 1, 1)
+                    .map(|unix_epoch| unix_epoch + Duration::days(i64::from(*v)))
+                    .unwrap();
+                fmt::Display::fmt(&date.format("%Y-%m-%d"), f)
+            }
+            ValueRef::Tuple(ref vs) => {
+                let cells: Vec<String> = vs.iter().map(|v| format!("{v}")).collect();
+                write!(f, "({})", cells.join(", "))
+            }
         }
     }
 }
@@ -237,6 +260,17 @@ impl<'a> From<ValueRef<'a>> for SqlType {
                 SqlType::DateTime(DateTimeType::DateTime64(*precision, *tz))
             }
             ValueRef::Map(k, v, _) => SqlType::Map(k, v),
+            ValueRef::Int256(_) => SqlType::Int256,
+            ValueRef::UInt256(_) => SqlType::UInt256,
+            ValueRef::Date32(_) => SqlType::Date32,
+            ValueRef::Tuple(ref vs) => {
+                let types: Vec<&'static SqlType> = vs.iter().map(|v| {
+                    let sql_type = SqlType::from(v.clone());
+                    let static_ref: &'static SqlType = sql_type.into();
+                    static_ref
+                }).collect();
+                SqlType::Tuple(types)
+            }
         }
     }
 }
@@ -319,6 +353,13 @@ impl<'a> From<ValueRef<'a>> for Value {
                     value_list.insert(key, value);
                 }
                 Value::Map(k, v, Arc::new(value_list))
+            }
+            ValueRef::Int256(v) => Value::Int256(v),
+            ValueRef::UInt256(v) => Value::UInt256(v),
+            ValueRef::Date32(v) => Value::Date32(v),
+            ValueRef::Tuple(vs) => {
+                let value_list: Vec<Value> = vs.iter().map(|v| v.clone().into()).collect();
+                Value::Tuple(Arc::new(value_list))
             }
         }
     }
@@ -417,6 +458,13 @@ impl<'a> From<&'a Value> for ValueRef<'a> {
                     ref_map.insert(key_ref, value_ref);
                 }
                 ValueRef::Map(k, v, Arc::new(ref_map))
+            }
+            Value::Int256(v) => ValueRef::Int256(*v),
+            Value::UInt256(v) => ValueRef::UInt256(*v),
+            Value::Date32(v) => ValueRef::Date32(*v),
+            Value::Tuple(vs) => {
+                let ref_vec: Vec<ValueRef<'a>> = vs.iter().map(|v| From::from(v)).collect();
+                ValueRef::Tuple(Arc::new(ref_vec))
             }
         }
     }


### PR DESCRIPTION
# TL;DR
Add support for ClickHouse's `Nothing` type in the `SqlType` enum. This type represents zero-byte-per-row values and is primarily used as `Nullable(Nothing)` for columns of all NULLs.

# Changes
- Add `Nothing` variant to `SqlType` enum
- Add `NothingColumnData` implementation (zero bytes per row — reads/writes nothing, tracks only row count)
- Handle `"Nothing"` in column factory (`load_data` and `from_type`)
- Handle `Nothing` in `Value::default()`, returning `Nullable(Left(&SqlType::Nothing))`
- Register the `nothing` module in `column/mod.rs`